### PR TITLE
Fix "cannot open file" when environment variables are present

### DIFF
--- a/src/DOS64STB.asm
+++ b/src/DOS64STB.asm
@@ -222,13 +222,13 @@ start16 proc
     int 21h
     mov es,bx
     mov es,es:[002Ch]
-    xor di,di
-    xor al,al
+    mov di,1
+    xor ax,ax
 @@:
-    repnz scasb
-    cmp byte ptr es:[di],0
-    jnz @B
-    add di,3
+    dec di
+    scasw
+    jne @B
+    add di,2
     mov word ptr fname+0,di
     mov word ptr fname+2,es
     pop es


### PR DESCRIPTION
The existing code wasn't able to skip over a non-empty environment block (the prebuilt mon64.exe would only launch for me on DOS 5.0/6.0 if I removed all environment variables before launching it).