### PR TITLE
Add EMS / VCPI support

### DIFF
--- a/src2/Dos64stb2.asm
+++ b/src2/Dos64stb2.asm
@@ -1476,10 +1476,13 @@ make_exc_gates:
     mov ax,SEL_CODE64
     stosw
     mov ax,8E00h
-    cmp ecx, 20	; 32-0Ch - i.e. this is the double-fault gate
-    jne @F
-    mov al,1	; PluM modification 1 Aug: IST 1
+    cmp ecx, 24	; 32-8 - i.e. this is the double-fault gate
+    je @F
+    cmp ecx, 20	; 32-0Ch - i.e. this is the stack-fault gate
+    jne @@ist_set
 @@:
+    mov al,1	; IST 1 - TODO: Different ISTs for #SS and #DF?
+@@ist_set:
     stosd
     xor eax, eax
     stosd


### PR DESCRIPTION
Hello! For fun, I've enhanced the "src2" version of the stub to be able to use EMS memory rather than XMS if available, and to use the VCPI interface to get out of VM86 mode. I guess it means memory is more limited when an EMS manager is running, but it's better than nothing…